### PR TITLE
Feature | Throw error if Model isn't registered

### DIFF
--- a/___tests___/index.test.js
+++ b/___tests___/index.test.js
@@ -328,6 +328,14 @@ describe('mockingoose', () => {
 			expect(JSON.stringify(mockingoose.User)).toBe(mockString);
 			expect(mockingoose.toJSON()).toEqual(mocksObject);
 		});
+
+		it('should throw an error if model does not exists', () => {
+			mockingoose.None.toReturn([{ not: 'exitsts' }]);
+
+			return User.find().then(users => {
+				expect(users).toHaveLength(1);
+			});
+		})
 	});
 
 	describe('check all instance methods', () => {

--- a/___tests___/index.test.js
+++ b/___tests___/index.test.js
@@ -330,11 +330,12 @@ describe('mockingoose', () => {
 		});
 
 		it('should throw an error if model does not exists', () => {
-			mockingoose.None.toReturn([{ not: 'exitsts' }]);
 
-			return User.find().then(users => {
-				expect(users).toHaveLength(1);
-			});
+			function addMock() {
+				mockingoose.None.toReturn({});
+			}
+
+			expect(addMock).toThrow();
 		})
 	});
 

--- a/src/index.js
+++ b/src/index.js
@@ -174,6 +174,9 @@ const traps = {
   get(target, prop) {
     if (target.hasOwnProperty(prop)) return Reflect.get(target, prop);
 
+    // Check if model (prop) is registered with mongoose.
+    mongoose.model(prop);
+
     return {
       toReturn(o, op = 'find') {
         target.__mocks.hasOwnProperty(prop)


### PR DESCRIPTION
address #35 showing an error if the model passed to mockingoose is not exists:

```js
mockingoose.None.toReturen([]);
```

`None` is not registered with mongoose will throw MissingSchema Error:

```
MissingSchemaError: Schema hasn't been registered for model "None".
Use mongoose.model(name, schema)
```