### PR TITLE
[RFC] Implement initial version of mock function support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib",
   "scripts": {
     "test": "jest",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "start": "babel-node ./src",
     "build": "babel src -d lib -s"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,45 @@ mongoose.createConnection = jest
     model: mongoose.model.bind(mongoose),
   });
 
+/**
+ * Gets the mock functions for a given model, creating objects if they are missing.
+ */
+function getModelMockFunctions(modelName) {
+  if (!modelName) throw new Error('Model name must be defined');
+
+  let allMockFunctions = mockingoose.__mockFunctions;
+  if (!allMockFunctions) allMockFunctions = mockingoose.__mockFunctions = {};
+
+  let modelMockFunctions = allMockFunctions[modelName];
+  if (!modelMockFunctions) modelMockFunctions = allMockFunctions[modelName] = {};
+
+  return modelMockFunctions;
+}
+
+/**
+ * Gets the mock function for a given model and op, creating objects and mocks as needed.
+ */
+function getMockFunction(modelName, opName) {
+  if (!opName) throw new Error('Op name must be defined');
+
+  const modelMockFunctions = getModelMockFunctions(modelName);
+
+  let mockFunction = modelMockFunctions[opName];
+  if (!mockFunction) mockFunction = modelMockFunctions[opName] = jest.fn();
+
+  return mockFunction;
+}
+
+/**
+ * Retrieves a mock function and applies the supplied handler to the mock function before
+ * invoking the mock function itself on behalf of the caller.
+ */
+function getApplyMock(modelName, opName, mockHandler, args) {
+  const mockFn = getMockFunction(modelName, opName);
+  mockFn.mockImplementation(mockHandler);
+  return mockFn.apply(this, args);
+}
+
 const ops = [
   'find',
   'findOne',
@@ -53,48 +92,86 @@ const mockedReturn = function (cb) {
   return Promise.resolve(mock);
 };
 
-ops.forEach(op => {
-  mongoose.Query.prototype[op] = jest.fn().mockImplementation(function (criteria, doc, options, callback) {
-    switch (arguments.length) {
-      case 4:
-      case 3:
-        if (typeof options === 'function') {
-          callback = options;
-          options = {};
-        }
-        break;
-      case 2:
-        if (typeof doc === 'function') {
-          callback = doc;
-          doc = criteria;
-          criteria = undefined;
-        }
-        options = undefined;
-        break;
-      case 1:
-        if (typeof criteria === 'function') {
-          callback = criteria;
-          criteria = options = doc = undefined;
-        } else {
-          doc = criteria;
-          criteria = options = undefined;
-        }
+/**
+ * Common code path that is invoked by every query based mock
+ * function. Which one made the call depends entirely on the
+ * operation.
+ */
+function queryMockFunctionHandler(criteria, doc, options, callback) {
+  switch (arguments.length) {
+  case 4:
+  case 3:
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
     }
+    break;
+  case 2:
+    if (typeof doc === 'function') {
+      callback = doc;
+      doc = criteria;
+      criteria = undefined;
+    }
+    options = undefined;
+    break;
+  case 1:
+    if (typeof criteria === 'function') {
+      callback = criteria;
+      criteria = options = doc = undefined;
+    } else {
+      doc = criteria;
+      criteria = options = undefined;
+    }
+  }
 
+  return callback ? this.exec.call(this, callback) : this;
+}
+
+/**
+ * Replacement for the Query operation function on the Mongoose Query
+ * prototype. Kinda like a proxy that ensures we call the right mock
+ * function before continuing.
+ */
+function getQueryOpHandler(op) {
+  return function() {
+    const { model: { modelName } } = this;
     this.op = op;
+    return getApplyMock.call(this, modelName, op, queryMockFunctionHandler, arguments);
+  };
+}
 
-    if (!callback) return this;
+ops.forEach(op => mongoose.Query.prototype[op] = getQueryOpHandler(op));
 
-    return this.exec.call(this, callback);
-  });
-});
+mongoose.Query.prototype.exec = function() {
+  const { model: { modelName } } = this;
+  // Op should have already been set by now.  So don't adjust it.
+  return getApplyMock.call(this, modelName, 'exec', mockedReturn, arguments);
+};
 
-mongoose.Query.prototype.exec = jest.fn().mockImplementation(function cb(cb) {
-  return mockedReturn.call(this, cb);
-});
+function aggregateExecMockFunctionHandler(cb) {
+	const { _model: { modelName } } = this;
+
+	let mock = mockingoose.__mocks[modelName] && mockingoose.__mocks[modelName].aggregate;
+
+	let err = null;
+
+	if (mock instanceof Error) err = mock;
+
+	if (cb) return cb(err, mock);
+
+	if (err) return Promise.reject(err);
+
+	return Promise.resolve(mock);
+}
+
+// XXX: Aggregate.exec mock function conflicts with the Query.exec mock function. How to solve?
+mongoose.Aggregate.prototype.exec = function() {
+  const { _model: { modelName } } = this;
+  return getApplyMock.call(this, modelName, 'exec', aggregateExecMockFunctionHandler, arguments);
+}
 
 mongoose.Aggregate.prototype.exec = jest.fn().mockImplementation(function cb(cb) {
-	const { _model: { modelName } } = this;
+  const { _model: { modelName } } = this;
 
 	let mock = mockingoose.__mocks[modelName] && mockingoose.__mocks[modelName].aggregate;
 
@@ -114,27 +191,33 @@ const instance = [
   'save'
 ];
 
-instance.forEach(methodName => {
-  mongoose.Model.prototype[methodName] = jest.fn().mockImplementation(function (options, cb) {
-    const op = methodName;
-    const { modelName } = this.constructor;
+function instanceMockFunctionHandler(options, cb) {
+  const op = this.op;
 
-    if (typeof options === 'function') cb = options;
+  if (typeof options === 'function') cb = options;
 
-    Object.assign(this, { op, model: { modelName } });
+  const hooks = this.constructor.hooks
 
-    const hooks = this.constructor.hooks
+  return new Promise((resolve, reject) => {
+    hooks.execPre(op, this, [cb], (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
 
-    return new Promise((resolve, reject) => {
-      hooks.execPre(op, this, [cb], (err) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+      const ret = mockedReturn.call(this, cb);
 
-        const ret = mockedReturn.call(this, cb);
+      if (cb) {
+        hooks.execPost(op, this, [ret], (err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
 
-        if (cb) {
+          resolve(ret);
+        });
+      } else {
+        ret.then((ret) => {
           hooks.execPost(op, this, [ret], (err) => {
             if (err) {
               reject(err);
@@ -143,29 +226,33 @@ instance.forEach(methodName => {
 
             resolve(ret);
           });
-        } else {
-          ret
-            .then((ret) => {
-              hooks.execPost(op, this, [ret], (err) => {
-                if (err) {
-                  reject(err);
-                  return;
-                }
-
-                resolve(ret);
-              });
-            })
-            .catch(reject);
-        }
-      });
+        }).catch(reject);
+      }
     });
   });
-});
+}
+
+/**
+ * Replacement for the instance operation function on the Mongoose
+ * Model prototype. Kinda like a proxy that ensures we call the right
+ * mock function before continuing.
+ */
+function getInstanceOpHandler(op) {
+  return function() {
+    const { modelName } = this.constructor;
+    Object.assign(this, { op, model: { modelName } });
+    return getApplyMock.call(this, modelName, op, instanceMockFunctionHandler, arguments);
+  };
+}
+
+instance.forEach(op => mongoose.Model.prototype[op] = getInstanceOpHandler(op));
 
 jest.doMock('mongoose', () => mongoose);
 
 const target = {
   __mocks: {},
+  __mockFunctions: {},
+  clearAll() { this.__mockFunctions = {}; },
   resetAll() { this.__mocks = {}; },
   toJSON() { return this.__mocks; },
 };
@@ -183,8 +270,28 @@ const traps = {
         return this;
       },
 
+      clear(op) {
+        if (op) {
+          const mockFunction = getMockFunction(prop, op);
+          mockFunction.clear();
+        } else {
+          const modelMockFunctions = getModelMockFunctions(prop);
+          Object.keys(modelMockFunctions).forEach(op => {
+            const mockFunction = getMockFunction(prop, op);
+            mockFunction.clear();
+          });
+        }
+
+        return this;
+      },
+
+      getMock(op) {
+        return getMockFunction(prop, op);
+      },
+
       reset(op) {
         op && delete target.__mocks[prop][op] || delete target.__mocks[prop];
+        op && delete target.__mockFunctions[prop][op] || delete target.__mockFunctions[prop];
 
         return this;
       },


### PR DESCRIPTION
Hey @alonronin,

   This is my initial RFC patch for full Jest mock function support in Mockingoose.  I still need to add tests and verify the sanity of everything and update the README  and more but as it currently stands it is passing all existing tests.  Please have a look and give me your feedback.  **Please do not merge this PR at this time**.

   There is a fair bit of change here.  The prototypes on the Query, Aggregate and Implementation operations are no longer jest methods as they previously were.  Now they are proxy functions that find the correct jest mock function (based on the model being used) or create it if it does not yet exist.  This is needed because if users want to track the calls on a model's operation, we need separate jest methods for each one.  This way a call to `Foo.findOne` will not register on the same jest mock function as `Bar.findOne` as it previously would.  I have also added `clear` and `clearAll` functions that are synonymous with the jest mock function clear method and have implemented them with the  same behavior as the `reset` and `resetAll` series of calls for consistency.  I have also ensured that invoking reset also resets the jets mock functions too.  And finally I have added the `getMock` function on every model to be able to retrieve the Mock function itself.

   What I am looking for here are things you consider blockers (obviously) and general feedback about structure and where things can be improved (if you have such feedback).  I have a problem of overlap between the Aggregate and Query `find` operations because these two will stomp on one-another.  Any thoughts on that one?  Beyond that let's work on getting this in and solving https://github.com/alonronin/mockingoose/issues/47