### PR TITLE
Fix module export in type definitions

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -59,4 +59,4 @@ declare const mockingoose: Proxy;
  * @param {string | mongoose.Model} model either a string model name, or a mongoose.Model instance
  */
 declare const mockModel: (model: string | mongoose.Model<any, {}>) => Mock;
-export default mockingoose;
+export = mockingoose;


### PR DESCRIPTION
**TL;DR:** From https://github.com/microsoft/TypeScript/issues/7185#issuecomment-354566288:

> `export =` and `import x = require('./x')` corresponds to CommonJS/AMD/etc.'s notion of `module.exports`:
> 
> ```js
> // ./a.js
> module.exports = { a: 10, b: 20 };
> 
> // ./b.js
> let a = require('./a');
> ```

Therefore the correct way to export the module in its type definitions would be using `export =`, and importing it should be done using `import mockingoose = require('mockingoose')`.

---

The module is exported using `module.exports =`, and the current type definitions export the module using `export default`:
https://github.com/alonronin/mockingoose/blob/8090c8f729df8822145c579011566d3475352f7f/src/index.js#L382
https://github.com/alonronin/mockingoose/blob/8090c8f729df8822145c579011566d3475352f7f/types.d.ts#L62

This prevents TS users using `allowSyntheticDefaultImports: true` from being able to import the package correctly:

```ts
import mockingoose from 'mockingoose';

mockingoose.resetAll();
//          ~~~~~~~~
//          Property 'resetAll' does not exist on type 'typeof import("path/to/node_modules/mockingoose/types")'. ts(2339)
```

The following does pass TypeScript's compiler but fails at runtime:
```ts
import mockingoose from 'mockingoose';

mockingoose.default.resetAll();
//          ^^^^^^^
//          TypeError: mockingoose_1.default.default is not a function
```

Even after the proposed change, a regular import won't work at runtime:
```ts
import mockingoose from 'mockingoose';
//     ^^^^^^^^^^^
//     TypeError: (0 , mockingoose_1.default) is not a function

mockingoose.resetAll();
```

Finally, the following does work after the proposed change, as expected as it is a CommonJS module:
```ts
// Works 🎉
import mockingoose = require('mockingoose');

mockingoose.resetAll();
```

Until the issue is fixed, as in the proposed change, TS users using `allowSyntheticDefaultImports: true` are forced to use `const mockingoose = require('mockingoose')` which loses all typings.