### PR TITLE
Fix hooks

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -863,5 +863,46 @@ describe('mockingoose', () => {
         expect(postHook).toHaveBeenCalled();
       });
     });
+
+    describe('Query operations', () => {
+      const ops = [
+        'find',
+        'findOne',
+        'distinct',
+        'findOneAndUpdate',
+        'findOneAndDelete',
+        'findOneAndReplace',
+        'replaceOne',
+        'updateOne',
+        'updateMany',
+        'deleteOne',
+        'deleteMany',
+      ] as const;
+
+      it.each(ops)('%s', async (op) => {
+        const schema = new mongoose.Schema({
+          name: String,
+        });
+
+        const preHook = vi.fn();
+        const postHook = vi.fn();
+        schema.pre(op, preHook);
+        schema.post(op, postHook);
+
+        const Model = mongoose.model(`ModelQueryHooks_${op}`, schema);
+        mockingoose(Model).toReturn({ name: 'test' }, op);
+
+        const args: any[] = [];
+
+        if (['updateOne', 'updateMany', 'replaceOne'].includes(op)) {
+          args.push({}, {});
+        }
+
+        await (Model as any)[op](...args);
+
+        expect(preHook).toHaveBeenCalled();
+        expect(postHook).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -818,6 +818,26 @@ describe('mockingoose', () => {
   });
 
   describe('hooks', () => {
+    describe('Model.create', () => {
+      it('should call hooks', async () => {
+        const schema = new mongoose.Schema({
+          name: String,
+        });
+
+        const preHook = vi.fn();
+        const postHook = vi.fn();
+        schema.pre('save', preHook);
+        schema.post('save', postHook);
+
+        const Model = mongoose.model('ModelCreateHooks', schema);
+        mockingoose(Model).toReturn({ name: 'test' }, 'save');
+        await Model.create({ name: 'test' });
+
+        expect(preHook).toHaveBeenCalled();
+        expect(postHook).toHaveBeenCalled();
+      });
+    });
+
     describe('Document.save', () => {
       it('should call hooks', async () => {
         const schema = new mongoose.Schema({

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -816,4 +816,32 @@ describe('mockingoose', () => {
       expect(result.toObject()).toMatchObject({ name: 'test' });
     });
   });
+
+  describe('hooks', () => {
+    describe('Document.save', () => {
+      it('should call hooks', async () => {
+        const schema = new mongoose.Schema({
+          name: String,
+        });
+
+        const preHook = vi.fn();
+        const postHook = vi.fn();
+        schema.pre('save', preHook);
+        schema.post('save', postHook);
+
+        const Model = mongoose.model('ModelSaveHooks', schema);
+        mockingoose(Model).toReturn({ name: 'test' }, 'save');
+        const doc = await Model.create({ name: 'test' });
+
+        preHook.mockClear();
+        postHook.mockClear();
+
+        doc.name = 'test2';
+        await doc.save();
+
+        expect(preHook).toHaveBeenCalled();
+        expect(postHook).toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,8 +212,23 @@ ops.forEach((op) => {
 
 // Patch Query.prototype.exec
 (mongoose.Query.prototype as any).exec = createMockFn().mockImplementation(
-  function (this: any, cb?: Function) {
-    return mockedReturn.call(this, cb);
+  async function (this: any, cb?: Function) {
+    // Ensure that the $__ property exists (needed for some hooks)
+    this.$__ ??= {};
+
+    const op = this.op;
+    const hooks = this.model.hooks;
+    try {
+      await hooks.execPre(op, this);
+      const ret = await mockedReturn.call(this);
+      await hooks.execPost(op, this, [ret]);
+
+      if (cb) return cb(null, ret);
+      return ret;
+    } catch (err) {
+      if (cb) return cb(err);
+      throw err;
+    }
   }
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,17 +382,14 @@ ops.forEach((op) => {
   return mockedReturn.call(this, cb);
 });
 
-// Patch instance methods (save, remove, $save)
-const instance = ['save', '$save'] as const;
-
-instance.forEach((methodName) => {
+['save', '$save'].forEach((methodName) => {
   (mongoose.Model.prototype as any)[methodName] =
     createMockFn().mockImplementation(async function (
       this: any,
       options: any,
       cb?: Function
     ) {
-      const op = methodName;
+      const op = 'save';
       const { modelName } = this.constructor;
 
       if (typeof options === 'function') {


### PR DESCRIPTION
This makes hooks run when executing query ops, which is needed for testing `timestamps: true`, as well as other custom hooks. It also makes `Model.create()` execute the "save" hooks, just like mongoose itself does.

This fixes #111.